### PR TITLE
MAINTAINER deprecated

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.5-slim
 
-MAINTAINER fernando@linuxacademy.com
+LABEL maintainer="fernando@linuxacademy.com"
 
 USER root
 


### PR DESCRIPTION
MAINTAINER is deprecated and replaced by LABEL in the Dockerfile. See https://docs.docker.com/engine/reference/builder/#maintainer-deprecated.