### PR TITLE
Bump MarkupSafe to 1.1.1 due to Docker build failing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask==0.12.2
 itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
-MarkupSafe==1.0
+MarkupSafe==1.1.1
 pathspec==0.5.5
 python-dateutil==2.6.1
 PyYAML==3.12


### PR DESCRIPTION
With MarkupSafe version 1.0 command docker build fails, bumping the dependency to newest version fixes the issue